### PR TITLE
Ability to add/omit ".js" from the end of a package name

### DIFF
--- a/cdn.js
+++ b/cdn.js
@@ -44,6 +44,17 @@ var findByName = findBy.bind(null, 'name');
 var findByFilename = findBy.bind(null, 'filename');
 var findByDescription = findBy.bind(null, 'description');
 
+var toggleExtension = function (name) {
+    var endsWithJS = /\.js$/;
+    if (endsWithJS.test(name)) {
+        name = name.replace(endsWithJS, '');
+    }
+    else {
+        name += '.js';
+    }
+    return name;
+};
+
 // The main cdnjs object
 
 var cdnjs = {
@@ -149,6 +160,7 @@ var cdnjs = {
     this.packages(function (err, packages) {
       if (err) return cb(err);
       var pkg = findByName(term.name, packages);
+      if (!pkg) pkg = findByName(toggleExtension(term.name), packages);
       if (!pkg) return cb(new Error("No such package found."));
       var version = this.getVersion(term.version, this.buildPackage(pkg));
       return cb(null, version);

--- a/test/test.js
+++ b/test/test.js
@@ -67,6 +67,26 @@ describe('url', function () {
     });
   });
 
+  it('should find a url for a known package with ".js" added to the name', function (done) {
+    this.timeout(5000);
+    cdnjs.url('jquery.js', function (err, result) {
+      should.not.exist(err);
+      result.should.be.ok;
+      result.name.should.equal('jquery');
+      done();
+    });
+  });
+
+  it('should find a url for a known package with ".js" missing from the name', function (done) {
+    this.timeout(5000);
+    cdnjs.url('require', function (err, result) {
+      should.not.exist(err);
+      result.name.should.equal('require.js');
+      result.url.should.match(/\/\/cdnjs.cloudflare.com\/ajax\/libs\/require.js\/(.*)\/require.min.js/);
+      done();
+    });
+  });
+
   it('should find a versioned url for a known package', function (done) {
     this.timeout(5000);
     cdnjs.url('angular.js@1.0.0', function (err, result) {


### PR DESCRIPTION
I find it difficult to remember which package names end in ".js" and which don't (i.e. "jquery" vs. "require.js") so I modified cdnjs.url so that if searching by name doesn't return anything the first time, it'll either add or remove ".js" to/from the name and search again.
