### PR TITLE
changed packages: to 'https://cdnjs.com/packages.json'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![build status](https://secure.travis-ci.org/phuu/cdnjs.png)](http://travis-ci.org/phuu/cdnjs)
 
-A search and URL retrival tool for [cdnjs](//cdnjs.com). It can be used globally, on your command line, or as a module.
+A search and URL retrieval tool for [cdnjs](//cdnjs.com). It can be used globally, on your command line, or as a module.
 
 It powers the [pulldown-api](https://github.com/phuu/pulldown-api).
 

--- a/cdn.js
+++ b/cdn.js
@@ -59,7 +59,7 @@ var toggleExtension = function (name) {
 
 var cdnjs = {
   urls: {
-    packages: 'https://raw.github.com/cdnjs/website/gh-pages/packages.json',
+    packages: 'https://cdnjs.com/packages.json',
     base: '//cdnjs.cloudflare.com/ajax/libs/'
   },
   /**


### PR DESCRIPTION
Github is [not too excited about scripts using raw.github.com ](https://github.com/blog/1482-heads-up-nosniff-header-support-coming-to-chrome-and-firefox), & the package list is available on the CDN so...

Not sure if you want to use http: or https:?
